### PR TITLE
Namespace this version of visualcaptcha

### DIFF
--- a/lib/visualcaptcha.rb
+++ b/lib/visualcaptcha.rb
@@ -1,7 +1,7 @@
 require "visualcaptcha/version"
 require "visualcaptcha/engine"
 
-module VisualCaptcha
+module GGVisualCaptcha
   autoload :ViewHelper, 'visualcaptcha/view'
   autoload :ControllerHelpers, 'visualcaptcha/controller'
   autoload :Utils, 'visualcaptcha/utils'
@@ -18,7 +18,7 @@ module VisualCaptcha
       @id = id
       @image = image
       @title = title
-      @encrypted = VisualCaptcha::Utils.generate_key(id)
+      @encrypted = GGVisualCaptcha::Utils.generate_key(id)
     end
 
   end

--- a/lib/visualcaptcha/controller.rb
+++ b/lib/visualcaptcha/controller.rb
@@ -1,4 +1,4 @@
-module VisualCaptcha
+module GGVisualCaptcha
   module ControllerHelpers
     def visual_captcha_valid?
       return true if Rails.env.test?

--- a/lib/visualcaptcha/engine.rb
+++ b/lib/visualcaptcha/engine.rb
@@ -1,10 +1,10 @@
 require 'rails'
 require 'visualcaptcha'
 
-module VisualCaptcha
+module GGVisualCaptcha
   class Engine < ::Rails::Engine
     config.after_initialize do
-      ActionView::Base.send(:include, VisualCaptcha::ViewHelper)
+      ActionView::Base.send(:include, GGVisualCaptcha::ViewHelper)
     end
   end
 end

--- a/lib/visualcaptcha/utils.rb
+++ b/lib/visualcaptcha/utils.rb
@@ -1,6 +1,6 @@
 require 'digest/sha1'
 
-module VisualCaptcha #:nodoc
+module GGVisualCaptcha #:nodoc
   module Utils #:nodoc
     def self.generate_key(*args)
       args << Time.now.to_s

--- a/lib/visualcaptcha/version.rb
+++ b/lib/visualcaptcha/version.rb
@@ -1,3 +1,3 @@
-module VisualCaptcha
+module GGVisualCaptcha
   VERSION = "1.0.0"
 end

--- a/lib/visualcaptcha/view.rb
+++ b/lib/visualcaptcha/view.rb
@@ -1,4 +1,4 @@
-module VisualCaptcha
+module GGVisualCaptcha
   module ViewHelper
 
     def show_visual_captcha(options = {})
@@ -7,7 +7,7 @@ module VisualCaptcha
       #key = visual_captcha_key('captcha')
 
       number = 6
-      captcha = VisualCaptcha::Captcha.new(number)
+      captcha = GGVisualCaptcha::Captcha.new(number)
       challenge = captcha.build
 
       session[:captcha] = challenge
@@ -23,9 +23,9 @@ module VisualCaptcha
 
       def visual_captcha_key(key_name = nil)
         if key_name.nil?
-          session[:captcha] ||= VisualCaptcha::Utils.generate_key(session[:id].to_s, 'captcha')
+          session[:captcha] ||= GGVisualCaptcha::Utils.generate_key(session[:id].to_s, 'captcha')
         else
-          VisualCaptcha::Utils.generate_key(session[:id].to_s, key_name)
+          GGVisualCaptcha::Utils.generate_key(session[:id].to_s, key_name)
         end
       end
   end

--- a/visualcaptcha.gemspec
+++ b/visualcaptcha.gemspec
@@ -5,7 +5,7 @@ require 'visualcaptcha/version'
 
 Gem::Specification.new do |gem|
   gem.name          = "visualcaptcha"
-  gem.version       = VisualCaptcha::VERSION
+  gem.version       = GGVisualCaptcha::VERSION
   gem.authors       = ["GhostGroup"]
   gem.description   = %q{Visual Captcha}
   gem.summary       = %q{Visual Captcha}


### PR DESCRIPTION
We need to be able to us this along side of https://github.com/emotionLoop/visualCaptcha-rubyGem
while we transition to using visualCaptcha-rubyGem 100%.
